### PR TITLE
Amber: Enable Wi-Fi bonding

### DIFF
--- a/configs/wifi/WCNSS_qcom_cfg.ini
+++ b/configs/wifi/WCNSS_qcom_cfg.ini
@@ -119,7 +119,9 @@ gApAutoChannelSelection=0
 BandCapability=0
 
 #Channel Bonding
+gChannelBondingMode2.4GHz=1
 gChannelBondingMode5GHz=1
+gChannelBondingMode24GHz=1
 
 #Say gGoKeepAlivePeriod(5 seconds) and gGoLinkMonitorPeriod(10 seconds).
 #For every 10 seconds DUT send Qos Null frame(i.e., Keep Alive frame if link


### PR DESCRIPTION
Wi-fi bonding increases internet speed up to 2x times. Tested on the device.